### PR TITLE
pass through unrecognized column types

### DIFF
--- a/src/operations/create.js
+++ b/src/operations/create.js
@@ -27,7 +27,7 @@ const TYPE_MAP = {
 const generateCreate = ({ schema, table }) => [ `CREATE TABLE IF NOT EXISTS ${ident(schema)}.${ident(table)}` ];
 
 const generateColumn = ({ name, type, length, nullable, default: defaultValue, encode }) => {
-  const colType = TYPE_MAP[type.toUpperCase()];
+  const colType = TYPE_MAP[type.toUpperCase()] || type.toUpperCase();
   const len = length ? `(${length})` : '';
   const notNull = nullable ? '' : ' NOT NULL';
   const def = defaultValue !== undefined ? ` DEFAULT ${defaultValue}` : '';

--- a/test/unit/redshift/create.test.js
+++ b/test/unit/redshift/create.test.js
@@ -39,6 +39,11 @@ describe('Redshift create adapter', () => {
     expect(translation).to.match(/id INT/);
   });
 
+  it('should passthru column types it doesnt recognize', () => {
+    const translation = translateCreation({ columns: [ { name: 'id', type: 'TIMESTAMP WITHOUT TIME ZONE' } ] });
+    expect(translation).to.match(/id TIMESTAMP WITHOUT TIME ZONE/);
+  });
+
   it('should join columns', () => {
     const translation = translateCreation({
       columns: [


### PR DESCRIPTION
I'm pulling table definitions out of pg_table_def and information schema and it gives full names for columns types like: `CHARACTER VARYING` and `TIMESTAMP WITH TIME ZONE`.  Legal pg and redshift column names but not accounted for in the type map.  I don't really want to have to blow up the type map to contain all these possibilities.  This PR passes through types it doesn't recognize in the type map.  

In which case, do we even need the type map?  or do we just need to make it much much bigger?
Basically, this PR makes the library pretty agnostic about column types.  It just tries them and lets it fail if they aren't valid.  Not sure if that's what we want.
